### PR TITLE
Closes #5 - Enable build for aarch64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "skip-icons-check": true,
-    "only-arches": [ "x86_64" ]
+    "skip-icons-check": true
 }


### PR DESCRIPTION
- For some reason this was forgotten

(tested on a Raspberry Pi, seems to work ok)